### PR TITLE
[ADD] related perday (product) in service, readonly if True

### DIFF
--- a/hotel/models/hotel_service.py
+++ b/hotel/models/hotel_service.py
@@ -22,6 +22,7 @@ class HotelService(models.Model):
     folio_id = fields.Many2one('hotel.folio', 'Folio', ondelete='cascade')
     ser_room_line = fields.Many2one('hotel.reservation', 'Room',
                                     default=_default_ser_room_line)
+    per_day = fields.fields.Boolean(related='product_id.per_day', 'Unit increment per day')
     service_line_ids = fields.One2many('hotel.service.line', 'service_id')
     product_qty = fields.Integer('Quantity')
     pricelist_id = fields.Many2one(related='folio_id.pricelist_id')

--- a/hotel/views/hotel_reservation_views.xml
+++ b/hotel/views/hotel_reservation_views.xml
@@ -250,6 +250,7 @@
                                                 options="{'create': False, 'create_edit': False}" />
                                             <!-- <field name="layout_category_id" groups="sale.group_sale_layout"/> -->
                                             <field name="name"/>
+                                            <field name="product_qty" attrs="{'readonly': [('per_day','=',True)]}"/>
                                             <field name="pricelist_id"/>
                                             <!-- <field name="ser_room_line" invisible="1" /> -->
                                             <!-- <field name="qty_delivered" invisible="1"


### PR DESCRIPTION
**Hotel Services line, by day and by person**
In 'per day' products, the quantity in service is read_only and calculate from service_line_ids. And the service_line_ids are calculate from checkin/out (but editable with priority manual changes)